### PR TITLE
Fix the sphinx build error.

### DIFF
--- a/axelrod/match.py
+++ b/axelrod/match.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from axelrod import Actions, Game
 from .deterministic_cache import DeterministicCache
 

--- a/axelrod/strategies/lookerup.py
+++ b/axelrod/strategies/lookerup.py
@@ -20,18 +20,18 @@ class LookerUp(Player):
     * my last action was a C the opponents
     * last action was a D
 
-    then the corresponding key would be
+    then the corresponding key would be::
 
         ('C', 'C', 'D')
 
     and the value would contain the action to play on this turn.
 
     Some well-known strategies can be expressed as special cases; for example
-    Cooperator is given by the dict:
+    Cooperator is given by the dict::
 
         {('', '', '') : C}
 
-    where m and n are both zero. Tit-For-Tat is given by:
+    where m and n are both zero. Tit-For-Tat is given by::
 
        {('', 'C', 'D'): D,
         ('', 'D', 'D'): D,
@@ -42,7 +42,7 @@ class LookerUp(Player):
 
     Lookup tables where the action depends on the opponent's first actions (as
     opposed to most recent actions) will have a non-empty first string in the
-    tuple. For example, this fragment of a dict:
+    tuple. For example, this fragment of a dict::
 
        {('C', 'C', 'C'): C,
         ('D', 'C', 'C'): D}
@@ -53,7 +53,7 @@ class LookerUp(Player):
 
     To denote lookup tables where the action depends on sequences of actions
     (so m or n are greater than 1), simply concatenate the strings together.
-    Below is an incomplete example where m=3 and n=2.
+    Below is an incomplete example where m=3 and n=2::
 
        {('CC', 'CDD', 'CCC'): C,
         ('CD', 'CCD', 'CCC'): D}

--- a/axelrod/strategies/lookerup.py
+++ b/axelrod/strategies/lookerup.py
@@ -33,11 +33,10 @@ class LookerUp(Player):
 
     where m and n are both zero. Tit-For-Tat is given by:
 
-        {('', 'C', 'D'): D,
-         ('', 'D', 'D'): D,
-         ('', 'C', 'C'): C,
-         ('', 'D', 'C'): C,
-        }
+       {('', 'C', 'D'): D,
+        ('', 'D', 'D'): D,
+        ('', 'C', 'C'): C,
+        ('', 'D', 'C'): C}
 
     where m=1 and n=0.
 
@@ -45,9 +44,8 @@ class LookerUp(Player):
     opposed to most recent actions) will have a non-empty first string in the
     tuple. For example, this fragment of a dict:
 
-        {('C', 'C', 'C'): C,
-         ('D', 'C', 'C'): D,
-        }
+       {('C', 'C', 'C'): C,
+        ('D', 'C', 'C'): D}
 
     states that if self and opponent both cooperated on the previous turn, we
     should cooperate this turn unless the opponent started by defecting, in
@@ -57,9 +55,9 @@ class LookerUp(Player):
     (so m or n are greater than 1), simply concatenate the strings together.
     Below is an incomplete example where m=3 and n=2.
 
-        {('CC', 'CDD', 'CCC'): C,
-         ('CD', 'CCD', 'CCC'): D,
-        }
+       {('CC', 'CDD', 'CCC'): C,
+        ('CD', 'CCD', 'CCC'): D}
+
     """
 
     name = 'LookerUp'


### PR DESCRIPTION
There's two commits here:
- 27128eaf10d2d6588c4604a9be921ff4511c9e54: this just does enough (basically sphinx was freaking out because of that trailing `}`)
- 865b083e6d6ab42ee1c228311227fc67e9c235e7: adds something that makes the rendered docs look a bit nicer. Here's current master: https://www.dropbox.com/s/9vsr067ag67c445/Screenshot%202016-08-07%2010.07.15.png?dl=0 and here is what it looks like with this commit: https://www.dropbox.com/s/xr9ilbp6xeg0t7u/Screenshot%202016-08-07%2010.05.56.png?dl=0
